### PR TITLE
Add Electron desktop packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,23 @@ make check             # Check environment
 make quick-start       # Setup + guidance for new users
 ```
 
+## 📦 Packaging
+
+Build desktop installers for the Electron version of the app:
+
+```bash
+cd frontend
+npm run electron:build
+```
+
+The command above runs `electron-builder` and produces a `.dmg` on macOS,
+a Windows installer using NSIS, and an AppImage for Linux. During development
+you can launch the Electron app with:
+
+```bash
+npm run electron:dev
+```
+
 ### API Endpoints
 
 #### Training API (Port 8000)

--- a/frontend/electron-main.js
+++ b/frontend/electron-main.js
@@ -1,0 +1,51 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+
+let trainProcess;
+let serveProcess;
+
+function createWindow() {
+  const mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      contextIsolation: true,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, 'dist', 'index.html'));
+}
+
+function startBackends() {
+  const python = process.env.PYTHON || 'python';
+  const backendDir = path.join(__dirname, '..', 'backend');
+
+  trainProcess = spawn(python, [path.join(backendDir, 'train.py')], {
+    stdio: 'inherit',
+  });
+
+  serveProcess = spawn(python, [path.join(backendDir, 'serve.py')], {
+    stdio: 'inherit',
+  });
+
+  process.on('exit', () => {
+    trainProcess && trainProcess.kill();
+    serveProcess && serveProcess.kill();
+  });
+}
+
+app.whenReady().then(() => {
+  startBackends();
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "electron:dev": "npm run build && electron .",
+    "electron:build": "electron-builder"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -28,6 +30,34 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.27",
     "tailwindcss": "^3.3.3",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "electron": "^28.2.5",
+    "electron-builder": "^24.9.1"
+  },
+  "build": {
+    "appId": "com.make-your-own-llm",
+    "files": [
+      "dist/**/*",
+      "electron-main.js"
+    ],
+    "extraFiles": [
+      {
+        "from": "../backend",
+        "to": "backend",
+        "filter": [
+          "**/*"
+        ]
+      }
+    ],
+    "asar": false,
+    "mac": {
+      "target": "dmg"
+    },
+    "win": {
+      "target": "nsis"
+    },
+    "linux": {
+      "target": "AppImage"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add Electron main process that launches Python servers and loads the built React app
- extend `frontend/package.json` with Electron deps, build configuration and scripts
- document how to build installers with `electron-builder`

## Testing
- `make test` *(fails: file or directory not found: backend/tests/)*

------
https://chatgpt.com/codex/tasks/task_e_688217954e20832a98fb09ed01e11e3e